### PR TITLE
Fixing AM_INIT_AUTOMAKE deprecation warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_INIT([ardesia], [ardesia_version],
 
 AC_PREFIX_DEFAULT(/usr)
 AC_CONFIG_MACRO_DIR([m4macros])
-AM_INIT_AUTOMAKE(AC_PACKAGE_NAME, AC_PACKAGE_VERSION)
+AM_INIT_AUTOMAKE
 AM_CONFIG_HEADER(config.h)
 
 # Check if we have enabled debug support.


### PR DESCRIPTION
> configure.ac:14: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
> configure.ac:14: https://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
